### PR TITLE
Unfinalized array visitor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed `final` keyword from `ArrayVisitor` methods.
 
 ## [1.0.0] - 2022-01-07
 ### Added

--- a/src/Visitor/ArrayVisitor.php
+++ b/src/Visitor/ArrayVisitor.php
@@ -26,7 +26,7 @@ abstract class ArrayVisitor extends Visitor
      * @inheritDoc
      * @since 1.0.0
      */
-    final public function visit(NodeInterface $node): void
+    public function visit(NodeInterface $node): void
     {
         $this->result[] = $this->doVisit($node);
     }
@@ -44,7 +44,7 @@ abstract class ArrayVisitor extends Visitor
      * @since 1.0.0
      * @return \Generator The result.
      */
-    final public function getResult(): iterable
+    public function getResult(): iterable
     {
         yield from $this->result;
     }
@@ -54,7 +54,7 @@ abstract class ArrayVisitor extends Visitor
      * @since 1.0.0
      * @return array The result.
      */
-    final public function asArray(): array
+    public function asArray(): array
     {
         return $this->result;
     }


### PR DESCRIPTION
This PR removes the `final` keyword from the `abstract ArrayVisitor`. 

Reason for this is the `abstract` nature of the visitor. While you can get around a few inconviniences with the use of decorators, the developer experience isn't very nice when trying to do something custom with the `ArrayVisitor`. 

**Examples**

- You might want to prevent a `result` from being added in `::visit()` based on some logic
- You might want to enrich the value on retrieval in `getResult()` or `toArray()` which can only be done after visiting

These are very simple and reasonable things to want when using an `abstract` class.